### PR TITLE
[android-9.0.0_r11] remove unused variables for compilation

### DIFF
--- a/sdm845/gnss/GnssAdapter.cpp
+++ b/sdm845/gnss/GnssAdapter.cpp
@@ -1726,7 +1726,7 @@ GnssAdapter::updateClientsEventMask()
         mask |= LOC_API_ADAPTER_BIT_GNSS_MEASUREMENT;
         mask |= LOC_API_ADAPTER_BIT_GNSS_SV_POLYNOMIAL_REPORT;
 
-        LOC_LOGD("%s]: Auto usecase, Enable MEAS/POLY - mask 0x%x", __func__, mask);
+        LOC_LOGD("%s]: Auto usecase, Enable MEAS/POLY - mask 0x%" PRIu64 "", __func__, mask);
     }
 
     if (mAgpsCbInfo.statusV4Cb != NULL) {


### PR DESCRIPTION
remove unsed variables and fix few compiler issues

CRs-fixed: 2175735
Change-Id: I635a7503326928f43070aa2224bc3c3d6e1ff929